### PR TITLE
Issue #7: Upgrade shared LaTeX preamble (pdfTeX-only): typography, boxes, pandoc shims, footer metadata

### DIFF
--- a/papers/agentic-force-creation/requirements/moltbot-request-20260131-012034.md
+++ b/papers/agentic-force-creation/requirements/moltbot-request-20260131-012034.md
@@ -1,0 +1,32 @@
+# Moltbot Request
+
+Source issue: https://github.com/anboas/Whitepaper/issues/7
+
+Paper: agentic-force-creation
+
+Request:
+- Update  (shared preamble) to incorporate the suggested formatting improvements, but keep CI compiling with pdfTeX only (no XeLaTeX/LuaLaTeX required).
+
+Specific changes:
+1) Add  and keep the existing pdfTeX font stack (fontenc/inputenc/lmodern). Do NOT require .
+2) Typography defaults:
+   - 
+   - 
+   - 
+   - 
+3) Hyperref:
+   - keep colored links (current behavior), but set  too.
+4) tcolorbox defaults:
+   - add a  default block matching the suggested values
+   - define  as  using those defaults
+5) Footer metadata hooks:
+   - add  and  and show them in L/R footers (center stays page number)
+6) Pandoc compatibility shims:
+   - 
+   - 
+   - 
+
+Constraints:
+- Don’t break existing papers.
+- Keep changes limited to  unless absolutely necessary.
+- Preserve the existing visual identity (colors, basic look).


### PR DESCRIPTION
This PR was opened by Moltbot from chat instructions.

```text
Source issue: https://github.com/anboas/Whitepaper/issues/7

Paper: agentic-force-creation

Request:
- Update  (shared preamble) to incorporate the suggested formatting improvements, but keep CI compiling with pdfTeX only (no XeLaTeX/LuaLaTeX required).

Specific changes:
1) Add  and keep the existing pdfTeX font stack (fontenc/inputenc/lmodern). Do NOT require .
2) Typography defaults:
   - 
   - 
   - 
   - 
3) Hyperref:
   - keep colored links (current behavior), but set  too.
4) tcolorbox defaults:
   - add a  default block matching the suggested values
   - define  as  using those defaults
5) Footer metadata hooks:
   - add  and  and show them in L/R footers (center stays page number)
6) Pandoc compatibility shims:
   - 
   - 
   - 

Constraints:
- Don’t break existing papers.
- Keep changes limited to  unless absolutely necessary.
- Preserve the existing visual identity (colors, basic look).
```
