### PR TITLE
Issue #18: Design callout quote blocks (distinct squares) anchored near relevant sections

### DIFF
--- a/papers/agentic-force-creation/requirements/moltbot-request-20260131-021527.md
+++ b/papers/agentic-force-creation/requirements/moltbot-request-20260131-021527.md
@@ -1,0 +1,18 @@
+# Moltbot Request
+
+Source issue: https://github.com/anboas/Whitepaper/issues/18
+
+Paper: agentic-force-creation
+
+Request:
+Implement distinct callout/quote blocks as square boxes that sit near relevant text (visually distinct from body copy).
+
+Requirements:
+- Define a reusable LaTeX environment/macro for callout quotes (e.g., `quoteBox{...}`) using tcolorbox.
+- Boxes should be clearly squared/rectangular, with subtle border and consistent spacing.
+- Update existing inline pull quotes to use this callout box style where appropriate.
+
+Constraints:
+- Keep pdfTeX compatibility.
+- Prefer using existing tcolorbox dependency (avoid adding heavy new packages).
+- Don’t overuse—aim for high-signal placements.


### PR DESCRIPTION
This PR was opened by Moltbot from chat instructions.

```text
Source issue: https://github.com/anboas/Whitepaper/issues/18

Paper: agentic-force-creation

Request:
Implement distinct callout/quote blocks as square boxes that sit near relevant text (visually distinct from body copy).

Requirements:
- Define a reusable LaTeX environment/macro for callout quotes (e.g., `quoteBox{...}`) using tcolorbox.
- Boxes should be clearly squared/rectangular, with subtle border and consistent spacing.
- Update existing inline pull quotes to use this callout box style where appropriate.

Constraints:
- Keep pdfTeX compatibility.
- Prefer using existing tcolorbox dependency (avoid adding heavy new packages).
- Don’t overuse—aim for high-signal placements.
```
