### PR TITLE
Fix #14: Trust Scope Manifest YAML as LaTeX code block

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -112,7 +112,7 @@ Trust scope decomposes into four parameters. Each parameter is measurable and te
 
 A required Trust Scope Manifest per agent family (e.g., enterprise, intel, cyber, battle management) includes approval gates and escalation triggers. Below is a drop-in YAML structure, expanded with DoD-specific examples for clarity:
 
-\begin{verbatim}
+\begin{yamlblock}
 trust_scope_manifest:
   agent_name: "enterprise-agents.v1"
   mission_threads:
@@ -156,7 +156,7 @@ trust_scope_manifest:
       - "policy_as_code_enforcement"  # Enforce ROE
     kill_switch: true               # Immediate halt capability
     immutable_audit_logging: true   # Tamper-proof records
-\end{verbatim}
+\end{yamlblock}
 
 This expanded framework can be integrated into DoD\textquotesingle s ATO processes, with initial pilots in Category A agents to build confidence. It directly addresses the strategy\textquotesingle s call for "model objectivity" by requiring verifiable artifacts, while enabling rapid deployment through predefined thresholds. For auditability, manifests should be version-controlled (e.g., via Azure DevOps, as in my prior white paper "From PDFs to Pull Requests"), with changes triggering re-approval workflows. This not only operationalizes trust but also scales with force creation, ensuring agents remain aligned in evolving battlespaces.
 

--- a/tex/paper_preamble.tex
+++ b/tex/paper_preamble.tex
@@ -26,9 +26,30 @@
 \hypersetup{colorlinks=true, linkcolor=BrandAccent, urlcolor=BrandAccent}
 
 \usepackage[most]{tcolorbox}
+\usepackage{listings}
+\tcbuselibrary{listingsutf8,breakable}
 
 % Pandoc compatibility (some markdown->latex conversions emit this)
 \providecommand{\tightlist}{}
 
 \newtcolorbox{keytakeaway}{colback=white,colframe=BrandAccent,boxrule=0.8pt,arc=2pt,left=10pt,right=10pt,top=8pt,bottom=8pt}
+
+% Readable monospaced code block (pdfTeX-compatible)
+\newtcblisting{yamlblock}{
+  listing only,
+  breakable,
+  colback=black!2,
+  colframe=BrandAccent!60!black,
+  boxrule=0.6pt,
+  arc=2pt,
+  left=8pt,right=8pt,top=6pt,bottom=6pt,
+  listing options={
+    basicstyle=\ttfamily\footnotesize,
+    columns=fullflexible,
+    keepspaces=true,
+    breaklines=true,
+    showstringspaces=false
+  }
+}
+
 \newenvironment{execsummary}{\section*{Executive Summary}\vspace{-2pt}}{\vspace{6pt}}


### PR DESCRIPTION
Fixes #14.

- Adds a pdfTeX-compatible `yamlblock` (tcolorbox + listings) in `tex/paper_preamble.tex`
- Replaces the Trust Scope Manifest `verbatim` block with `yamlblock` in the Agentic Force Creation paper

This keeps indentation, uses monospaced font, and visually distinguishes the manifest as a code block without adding generated artifacts.