### PR TITLE
Tighten high-visibility quotations for precision (closes #44)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -34,11 +34,11 @@
 \begin{execsummary}
 \vspace{0.3\baselineskip}
 \begin{calloutquote}
-``Force creation removes humans from the bottleneck.''
+``Force creation removes human reaction time as the bottleneck.''
 \end{calloutquote}
 
 % autopilot: pull-quotes insertion requested in PR
-\textbf{The shift:} The DoD is adopting AI as a \emph{force multiplier} (assistants) while the strategic inflection is \emph{force creation}: autonomous, intent-driven agents that execute mission threads within bounded authority and scale with compute.
+\textbf{The shift:} The DoD is adopting AI as a \emph{force multiplier} (assistants) while the strategic inflection is \emph{force creation}: autonomous, intent-driven agents operate with delegated authority, scaling through compute rather than human labor.
 
 \textbf{Why it matters:} In contested environments, decision tempo and execution density will exceed human relevance windows. If the DoD cannot field autonomy with verifiable trust scopes at tempo, adversaries will.
 
@@ -58,19 +58,19 @@
 
 The Department of Defense stands at a pivotal juncture in AI integration, yet there persists a disconnect between current perceptions and the impending reality. As evidenced by statements from senior leaders, such as the Army CIO\textquotesingle s view of AI as merely a ``good assistant,'' much of the DoD remains anchored in the force multiplication phase---where AI amplifies human efficiency in tasks like software development lifecycle (SDLC) processes, code generation, and analysis. This phase is valuable but limited, treating AI as a tool bound by human oversight and scale.
 
-In contrast, the horizon reveals force creation: autonomous agents driven by high-level intents, decoupling operational scale from human limitations and leveraging silicon and compute for exponential growth. In this paper, an `agent' is a software system that can plan, call tools, and execute actions toward a goal with bounded authority.
+In contrast, the horizon reveals force creation: autonomous agents driven by high-level intents, decoupling operational scale from human limitations and leveraging silicon and compute for exponential growth. In this paper, an `agent' is a software system that can plan, invoke tools, and execute actions toward a goal within bounded authority.
 
 \begin{calloutquote}
 ``Human capital scales linearly; compute scales exponentially.''
 \end{calloutquote}
 
-This shift is not speculative. Industry leaders like Anthropic CEO Dario Amodei have observed: ``I have engineers within Anthropic who say I don\textquotesingle t write any code anymore. I just let the model write the code, I edit it,'' projecting AI handling most or all coding end-to-end within 6--12 months[1]. OpenAI CEO Sam Altman echoes: ``We believe that, in 2025, we may see the first AI agents \textquotesingle join the workforce\textquotesingle{} and materially change the output of companies''[2]. In a recent update, Altman further emphasized the democratizing power of this technology: ``By the end of this year, for \$100--\$1000 of inference and a good idea, you\textquotesingle ll be able to create a company that could have been a unicorn 10 years ago''[3]. Elon Musk, CEO of xAI and Tesla, warns of the competitive edge: ``Companies that are entirely AI will demolish companies that are not''[4], underscoring that AI-native entities will operate at speeds and scales unattainable by legacy systems, making adaptation non-optional. The DoD\textquotesingle s own ``Artificial Intelligence Strategy'' (released January 9, 2026) acknowledges this momentum, calling for an ``AI-first'' warfighting force and initiatives like the ``Agent Network'' for AI-enabled battle management[5]. Yet, the strategy\textquotesingle s emphasis on experimentation and decision support risks underplaying the full autonomy required for force creation, potentially leaving the DoD vulnerable.
+This shift is not speculative. Industry leaders like Anthropic CEO Dario Amodei have observed: ``I have engineers within Anthropic who say I don\textquotesingle t write any code anymore. I just let the model write the code, I edit it,'' projecting AI handling most or all coding end-to-end within 6--12 months[1]. OpenAI CEO Sam Altman echoes: ``We believe that, in 2025, we may see the first AI agents \textquotesingle join the workforce\textquotesingle{} and materially change the output of companies''[2]. In a recent update, Altman further emphasized the democratizing power of this technology: ``By the end of this year, for \$100--\$1000 of inference and a good idea, you\textquotesingle ll be able to create a company that could have been a unicorn 10 years ago''[3]. Elon Musk, CEO of xAI and Tesla, frames the competitive implication starkly: ``Companies that are entirely AI will demolish companies that are not''[4], underscoring that AI-native entities will operate at speeds and scales unattainable by legacy systems, making adaptation non-optional. The DoD\textquotesingle s own ``Artificial Intelligence Strategy'' (released January 9, 2026) acknowledges this momentum, calling for an ``AI-first'' warfighting force and initiatives like the ``Agent Network'' for AI-enabled battle management[5]. Yet, the strategy\textquotesingle s emphasis on experimentation and decision support risks underplaying the full autonomy required for force creation, potentially leaving the DoD vulnerable.
 
 Central to this transition is the trust scope of agentics and autonomy: How much can we rely on these systems in classified, high-risk environments? Trust encompasses reliability, ethical alignment, verifiability, and risk tolerance. The DoD strategy prioritizes ``model objectivity'' and accepts ``risks of not moving fast enough outweigh the risks of imperfect alignment,'' but lacks detailed frameworks for trust in fully autonomous operations[5]. This white paper explores these elements to urge a more proactive stance, with a focus on intent-driven development and context engineering as foundational to force creation.
 
 \section{Reality Check: Why Agents Didn't `Join the Workforce' in 2025}\label{reality-check-why-agents-didnt-join-the-workforce-in-2025}
 
-Optimistic forecasts from leaders like Altman and Amodei suggested 2025 would see AI agents transforming workflows, yet this did not fully materialize. As Cal Newport reflected in his January 2026 essay, ``Why Didn\textquotesingle t AI \textquotesingle Join the Workforce\textquotesingle{} in 2025?'', agents struggled with reliability outside constrained environments, often failing in dynamic, real-world settings due to issues like context drift and unpredictable interactions[6]. Similarly, The New Yorker\textquotesingle s 2025-in-review piece noted that agents excelled in text-based terminals but faltered in broader applications, labeling 2025 as the start of a ``decade of the agent'' rather than an immediate revolution[7]. This reframes force creation as an engineering and governance challenge, not mere hype---underscoring the need for robust trust scopes and control planes to enable scalable autonomy in defense contexts.
+Optimistic forecasts from leaders like Altman and Amodei suggested 2025 would see AI agents transforming workflows, yet this did not fully materialize. As Cal Newport reflected in his January 2026 essay, ``Why Didn\textquotesingle t AI \textquotesingle Join the Workforce\textquotesingle{} in 2025?'', agents struggled with reliability outside constrained environments, often failing in dynamic, real-world settings due to issues like context drift and unpredictable interactions[6]. Similarly, The New Yorker\textquotesingle s 2025-in-review piece noted that agents excelled in text-based terminals but faltered in broader applications, labeling 2025 as the start of a ``decade of the agent'' rather than an immediate revolution[7]. This reframes force creation as an engineering and governance challenge, not a failure of model capability, underscoring the need for robust trust scopes and control planes to enable scalable autonomy in defense contexts.
 
 \section{The Paradigm Shift: From ``Build vs. Buy'' to ``Write Specs'' in Intent-Driven Development}\label{the-paradigm-shift-from-build-vs-buy-to-write-specs-in-intent-driven-development}
 
@@ -102,7 +102,7 @@ The implication is not that assistants are useless; it is that they do not remov
 
 \section{Trust Scope Framework: Defining and Operationalizing Trust in Agentic Systems}\label{trust-scope-framework-defining-and-operationalizing-trust-in-agentic-systems}
 
-Trust scope decomposes into four parameters. Each parameter is measurable and testable, allowing for iterative refinement based on real-world performance data.
+Trust scope decomposes into four explicit parameters. Each parameter is measurable and testable, allowing for iterative refinement based on real-world performance data.
 
 \begin{calloutquote}
 ``Trust is bounded authority plus verification.''
@@ -171,7 +171,7 @@ This expanded framework can be integrated into DoD\textquotesingle s ATO process
 
 \section{Agent Control Plane: Architectural Governance for Safe Autonomy}\label{agent-control-plane-architectural-governance-for-safe-autonomy}
 
-To operationalize compute-scaled autonomy, a dedicated Agent Control Plane is essential---a technical governance layer making force creation fieldable:
+To operationalize compute-scaled autonomy, a dedicated Agent Control Plane is essential, a technical governance layer that makes force creation fieldable:
 
 \begin{itemize}
 \item
@@ -285,11 +285,11 @@ This dovetails with OMB M-26--04\textquotesingle s emphasis on vendor documentat
 ``You can't recruit your way out of a compute deficit.''
 \end{calloutquote}
 
-By 2030, conflict advantage will increasingly be determined by decision tempo, context fidelity, and autonomous execution density. The relevant unit of capability will not be ``model quality'' in isolation, but ``agentic throughput under constraint'': agent-hours/day operating within approved trust scopes, closing mission threads with auditable logs and bounded authorities. Operationally, this is measurable: (1) agent-hours/day executed within approved trust scopes, (2) exception rate (percentage of actions requiring human escalation), (3) context freshness SLA under contested conditions, and (4) control-plane mean time to recover (MTTR) during deception and jamming. In contested environments, autonomy will not be optional; it will be required to operate inside human relevance windows, especially across cyber, electronic warfare, and battle management workflows. The practical implication is that the battlespace becomes a compute-and-agency competition: who can sense faster, interpret more reliably, and execute within policy constraints at machine speed.
+By 2030, conflict advantage will increasingly be determined by decision tempo, context fidelity, and autonomous execution density. The relevant unit of capability is not model quality in isolation, but agentic throughput under constraint: agent-hours/day operating within approved trust scopes, closing mission threads with auditable logs and bounded authorities. Operationally, this is measurable: (1) agent-hours/day executed within approved trust scopes, (2) exception rate (percentage of actions requiring human escalation), (3) context freshness SLA under contested conditions, and (4) control-plane mean time to recover (MTTR) during deception and jamming. In contested environments, autonomy will not be optional; it will be required to operate inside human relevance windows, especially across cyber, electronic warfare, and battle management workflows. The practical implication is that the battlespace becomes a compute-and-agency competition: who can sense faster, interpret more reliably, and execute within policy constraints at machine speed.
 
 \section{Human Relevance Windows}\label{human-relevance-windows}
 
-Human relevance windows are thresholds where human intervention remains viable: speed threshold (loop tempo), complexity threshold (option space), and contestation threshold (deception + uncertainty). In domains where the adversary can induce state changes faster than humans can observe-orient-decide, humans cannot remain in the critical loop. Humans must govern the loop, not execute it. This ties directly to trust scopes: Category A/B agents handle exceptions with humans on standby; Category C requires humans on high-consequence gating; Category D mandates humans on use-of-force judgment per policy.
+Human relevance windows are thresholds where human intervention remains viable: speed threshold (loop tempo), complexity threshold (option space), and contestation threshold (deception + uncertainty). In domains where the adversary can induce state changes faster than humans can observe-orient-decide, humans cannot remain in the critical loop. Humans must govern the loop, not execute it at machine speed. This ties directly to trust scopes: Category A/B agents handle exceptions with humans on standby; Category C requires humans on high-consequence gating; Category D mandates humans on use-of-force judgment per policy.
 
 \begin{calloutquote}
 ``Humans govern the loop; machines execute it.''
@@ -333,13 +333,13 @@ Sensors/telemetry $\rightarrow$ context engineering $\rightarrow$ agent orchestr
 
 \section{A Bounded Vignette: Contested Comms, High Tempo}\label{a-bounded-vignette-contested-comms-high-tempo}
 
-Scenario (contested comms, high tempo): Under intermittent connectivity, a battle-management agent family operates under Category C trust scope: it may fuse ISR and recommend COAs, but may only execute pre-approved non-kinetic actions (e.g., sensor re-tasking, deception routing) below a defined risk threshold. The control plane enforces tool mediation, budget limits, and escalation triggers when confidence decays or conflicting sources appear. The operational metric is not ``AI accuracy'' but ``time-to-credible-COA'' and ``exception rate'': how often humans must intervene, and whether autonomy sustains tempo without exceeding authority bounds.
+Scenario (contested comms, high tempo): Under intermittent connectivity, a battle-management agent family operates under Category C trust scope: it may fuse ISR and recommend COAs, but may only execute pre-approved non-kinetic actions (e.g., sensor re-tasking, deception routing) below a defined risk threshold. The control plane enforces tool mediation, budget limits, and escalation triggers when confidence decays or conflicting sources appear. The operational metric is not AI accuracy but time-to-credible COA and exception rate: how often humans must intervene, and whether autonomy sustains tempo without exceeding authority bounds.
 
 \begin{calloutquote}
 ``If humans must approve every action, you have already lost the tempo advantage.''
 \end{calloutquote}
 
-This shift is structurally driven by operational tempo and contestation dynamics.
+This shift is structurally driven by operational tempo, contestation, and scale asymmetry.
 
 \section{Current Developments and Case Studies: Evidence of the Gap in DoD Adoption}\label{current-developments-and-case-studies-evidence-of-the-gap-in-dod-adoption}
 
@@ -420,7 +420,7 @@ This roadmap supports rapid model refresh and barrier removal (DoD AI Strategy, 
 \item
   \textbf{Workforce Preparation}: Implement reskilling to shift from multiplication mindsets to spec-writing and agent oversight.
 \item
-  \textbf{Risk Management}: Prioritize speed with safeguards, recognizing ``risks of not moving fast enough'' (DoD AI Strategy, 2026), while addressing trust in agentic swarms via control planes.
+  \textbf{Risk Management}: Prioritize speed with enforceable safeguards, recognizing ``risks of not moving fast enough'' (DoD AI Strategy, 2026), while addressing trust in agentic swarms via control planes.
 \end{itemize}
 
 By refocusing, the DoD can lead in agentic dominion.
@@ -433,7 +433,7 @@ To ensure clarity and auditability, the following 10 terms are defined crisply, 
 \item
   \textbf{Force Multiplication}: AI increases throughput of existing human workstreams, bounded by human attention/approvals. Auditable: Measured by efficiency gains (e.g., tasks per human-hour) requiring constant oversight.
 \item
-  \textbf{Force Creation}: AI executes mission-relevant work with delegated authorities, scaling primarily with compute + access + permissions, not personnel. Auditable: Agent-hours per day \textgreater{} human-equivalent output; autonomous task closure rate \textgreater{} 80\%; human approval rate per mission thread \textless{} 20\%; compute-to-output elasticity (output increase per compute doubling) \textgreater{} 1.5x.
+  \textbf{Force Creation}: AI executes mission-relevant work with delegated authorities and pre-defined constraints, scaling primarily with compute + access + permissions, not personnel. Auditable: Agent-hours per day \textgreater{} human-equivalent output; autonomous task closure rate \textgreater{} 80\%; human approval rate per mission thread \textless{} 20\%; compute-to-output elasticity (output increase per compute doubling) \textgreater{} 1.5x.
 \item
   \textbf{Intent-Driven Development}: High-level goal specification triggering autonomous execution. Auditable: Specs-to-deployment time \textless{} 1 hour; success alignment \textgreater{} 95\%.
 \item


### PR DESCRIPTION
Closes #44.

Surgical sentence-level rewrites to reduce misinterpretation risk while preserving intent/tone.

Changes:
- Clarify bottleneck language (reaction time vs removing humans)
- Replace HR-ish phrasing (human labor)
- More formal agent definition language (invoke/within)
- Reframe Musk line as analysis vs endorsement
- Replace 'mere hype' with technical root cause framing
- Add 'explicit' to trust parameters
- Remove em-dash ambiguity in control-plane sentence
- Make throughput metric declarative (remove quote hedging)
- Tie structural shift to tempo + contestation + scale asymmetry
- Clarify governance vs machine-speed execution
- Clean metric sentence (remove quote clutter)
- Make safeguards enforceable
- Add pre-defined constraints to delegated authority