### PR TITLE
Fix comma splice in Agent Control Plane definition (closes #54)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -171,7 +171,7 @@ This expanded framework can be integrated into DoD\textquotesingle s ATO process
 
 \section{Agent Control Plane: Architectural Governance for Safe Autonomy}\label{agent-control-plane-architectural-governance-for-safe-autonomy}
 
-To operationalize compute-scaled autonomy, a dedicated Agent Control Plane is essential, a technical governance layer that makes force creation fieldable:
+To operationalize compute-scaled autonomy, a dedicated Agent Control Plane is essential: a technical governance layer that makes force creation fieldable.
 
 \begin{itemize}
 \item


### PR DESCRIPTION
Closes #54.

Deterministic fix (approved Variant 1): replace comma splice with definition-style colon.

- Before: `A dedicated Agent Control Plane is essential, a technical governance layer that makes force creation fieldable:`
- After:  `A dedicated Agent Control Plane is essential: a technical governance layer that makes force creation fieldable.`