### PR TITLE
Department of War rename + title indent fix + author role update (closes #58 #59 #60)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -8,10 +8,10 @@
 % Path is relative to repo root (CI compiles from repo root)
 \input{tex/paper_preamble.tex}
 
-\newcommand{\PaperTitle}{The Unrecognized Shift: From AI Force Multiplication to Force Creation in the Department of Defense}
+\newcommand{\PaperTitle}{The Unrecognized Shift: From AI Force Multiplication to Force Creation in the Department of War}
 \newcommand{\PaperSubtitle}{A White Paper on Agentic Autonomy, Trust Scopes, and Strategic Imperatives for Defense}
 \newcommand{\AuthorName}{Adam Boas}
-\newcommand{\AuthorRole}{Cloud Solutions Architect (defense modernization; agentic governance)}
+\newcommand{\AuthorRole}{Agentic Warfare Architect, Department of War}
 \newcommand{\PaperDate}{January 2026}
 \renewcommand{\ShortTitle}{AI Force Creation White Paper}
 \renewcommand{\DocVersion}{v1.0}
@@ -20,7 +20,7 @@
 
 \thispagestyle{empty}
 \vspace*{0.6in}
-{\Huge\bfseries\color{BrandAccent}\PaperTitle\par}
+\noindent{\Huge\bfseries\color{BrandAccent}\PaperTitle\par}
 \vspace{0.12in}
 {\large\color{BrandGray}\PaperSubtitle\par}
 \vspace{0.25in}
@@ -56,7 +56,7 @@
 
 \section{Introduction: The Overlooked Transition in DoD AI Adoption}\label{introduction-the-overlooked-transition-in-dod-ai-adoption}
 
-The Department of Defense stands at a pivotal juncture in AI integration, yet there persists a disconnect between current perceptions and the impending reality. As evidenced by statements from senior leaders, such as the Army CIO\textquotesingle s view of AI as merely a ``good assistant,'' much of the DoD remains anchored in the force multiplication phase---where AI amplifies human efficiency in tasks like software development lifecycle (SDLC) processes, code generation, and analysis. This phase is valuable but limited, treating AI as a tool bound by human oversight and scale.
+The Department of War stands at a pivotal juncture in AI integration, yet there persists a disconnect between current perceptions and the impending reality. As evidenced by statements from senior leaders, such as the Army CIO\textquotesingle s view of AI as merely a ``good assistant,'' much of the DoD remains anchored in the force multiplication phase---where AI amplifies human efficiency in tasks like software development lifecycle (SDLC) processes, code generation, and analysis. This phase is valuable but limited, treating AI as a tool bound by human oversight and scale.
 
 In contrast, the horizon reveals force creation: autonomous agents driven by high-level intents, decoupling operational scale from human limitations and leveraging silicon and compute for exponential growth. In this paper, an `agent' is a software system that can plan, invoke tools, and execute actions toward a goal within bounded authority.
 
@@ -476,7 +476,7 @@ New roles to support force creation:
 % Citation scheme: numeric [n] inline, numbered references.
 \begin{enumerate}[label={[\arabic*]}]
 \item
-  DoD AI Strategy (2026). ``Department of Defense Artificial Intelligence Strategy.'' media.defense.gov/2026/01/09/DoD-AI-Strategy.pdf (January 9, 2026).
+  DoW AI Strategy (2026). ``Department of War Artificial Intelligence Strategy.'' media.defense.gov/2026/01/09/DoD-AI-Strategy.pdf (January 9, 2026).
 \item
   Amodei, D. (2025). ``Remarks on AI Agents.'' World Economic Forum, weforum.org/agenda/2025/01/amodei-ai-agents (January 2025).
 \item


### PR DESCRIPTION
Closes #58.
Closes #59.
Closes #60.

Changes (agentic-force-creation):
- Replace “Department of Defense” → “Department of War” where it appears (including the paper title and the strategy reference label).
- Fix title indentation by forcing `\noindent` on the title line.
- Update author role to: `Agentic Warfare Architect, Department of War`.