### PR TITLE
Exec summary quote move + quote prominence/attribution + YAML line numbers (closes #62 #63 #64)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -32,11 +32,6 @@
 \newpage
 
 \begin{execsummary}
-\vspace{0.3\baselineskip}
-\begin{calloutquote}
-``Force creation removes human reaction time as the bottleneck.''
-\end{calloutquote}
-
 % autopilot: pull-quotes insertion requested in PR
 \textbf{The shift:} The DoD is adopting AI as a \emph{force multiplier} (assistants) while the strategic inflection is \emph{force creation}: autonomous, intent-driven agents operate with delegated authority, scaling through compute rather than human labor.
 
@@ -52,6 +47,11 @@
 \end{enumerate}
 
 \textbf{This paper provides:} a Trust Scope Framework, an Agent Control Plane blueprint, a partitioning model (enterprise $\rightarrow$ weapon autonomy), an adversarial threat model, and a 12--24 month roadmap aligned to DoD AI Strategy PSPs.
+
+\vspace{0.3\baselineskip}
+\begin{calloutquote}
+``Force creation removes human reaction time as the bottleneck.''
+\end{calloutquote}
 \end{execsummary}
 
 \section{Introduction: The Overlooked Transition in DoD AI Adoption}\label{introduction-the-overlooked-transition-in-dod-ai-adoption}

--- a/tex/paper_preamble.tex
+++ b/tex/paper_preamble.tex
@@ -60,7 +60,9 @@
   left=10pt,right=10pt,top=8pt,bottom=8pt,
   borderline west={2.2pt}{0pt}{BrandAccent}
 }
-\newenvironment{calloutquote}{\begin{calloutquotebox}\itshape\centering}{\end{calloutquotebox}}
+\newenvironment{calloutquote}
+  {\begin{calloutquotebox}\centering\bfseries\large\itshape}
+  {\par\smallskip\hfill{\normalfont\small\textcolor{BrandGray}{--- \AuthorName}}\end{calloutquotebox}}
 
 % Readable monospaced code block (pdfTeX-compatible)
 \newtcblisting{yamlblock}{
@@ -81,7 +83,11 @@
     breaklines=true,
     breakatwhitespace=true,
     showstringspaces=false,
-    upquote=true
+    upquote=true,
+    numbers=left,
+    stepnumber=1,
+    numbersep=10pt,
+    numberstyle=\ttfamily\scriptsize\color{BrandGray}
   }
 }
 


### PR DESCRIPTION
Closes #62.
Closes #63.
Closes #64.

- Moves the first executive summary pull quote to the bottom of the exec summary.
- Makes callout quotes more prominent (bold + slightly larger) and appends author attribution.
- Adds left-side line numbers to the YAML block via listings options.