### PR TITLE
Remove callout attribution + quotation marks (closes #72)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -50,7 +50,7 @@
 
 \vspace{0.3\baselineskip}
 \begin{calloutquote}
-``Force creation removes human reaction time as the bottleneck.''
+Force creation removes human reaction time as the bottleneck.
 \end{calloutquote}
 \end{execsummary}
 
@@ -65,7 +65,7 @@ This shift is not speculative. Industry leaders like Anthropic CEO Dario Amodei 
 Central to this transition is the trust scope of agentics and autonomy: How much can we rely on these systems in classified, high-risk environments? Trust encompasses reliability, ethical alignment, verifiability, and risk tolerance. The DoW strategy prioritizes ``model objectivity'' and accepts ``risks of not moving fast enough outweigh the risks of imperfect alignment,'' but lacks detailed frameworks for trust in fully autonomous operations[5]. This white paper explores these elements to urge a more proactive stance, with a focus on intent-driven development and context engineering as foundational to force creation.
 
 \begin{calloutquote}
-``Human capital scales linearly; compute scales exponentially.''
+Human capital scales linearly; compute scales exponentially.
 \end{calloutquote}
 
 \section{Reality Check: Why Agents Didn't `Join the Workforce' in 2025}\label{reality-check-why-agents-didnt-join-the-workforce-in-2025}
@@ -166,7 +166,7 @@ trust_scope_manifest:
 This expanded framework can be integrated into DoW\textquotesingle s ATO processes, with initial pilots in Category A agents to build confidence. It directly addresses the strategy\textquotesingle s call for ``model objectivity'' by requiring verifiable artifacts, while enabling rapid deployment through predefined thresholds. For auditability, manifests should be version-controlled (e.g., via Azure DevOps, as in my prior white paper ``From PDFs to Pull Requests''), with changes triggering re-approval workflows. This not only operationalizes trust but also scales with force creation, ensuring agents remain aligned in evolving battlespaces.
 
 \begin{calloutquote}
-``Trust is bounded authority plus verification.''
+Trust is bounded authority plus verification.
 \end{calloutquote}
 
 \section{Agent Control Plane: Architectural Governance for Safe Autonomy}\label{agent-control-plane-architectural-governance-for-safe-autonomy}
@@ -191,7 +191,7 @@ To operationalize compute-scaled autonomy, a dedicated Agent Control Plane is es
 This aligns with DoW AI Strategy requirements for rapid model refresh (deploy within \textasciitilde30 days of public release) and ATO reciprocity.
 
 \begin{calloutquote}
-``Control planes matter more than models.''
+Control planes matter more than models.
 \end{calloutquote}
 
 \section{Explicit Policy Partitioning: Enterprise Agents vs. Weapon/Autonomy Contexts}\label{explicit-policy-partitioning-enterprise-agents-vs-weaponautonomy-contexts}
@@ -284,7 +284,7 @@ This dovetails with OMB M-26--04\textquotesingle s emphasis on vendor documentat
 By 2030, conflict advantage will increasingly be determined by decision tempo, context fidelity, and autonomous execution density. The relevant unit of capability is not model quality in isolation, but agentic throughput under constraint: agent-hours/day operating within approved trust scopes, closing mission threads with auditable logs and bounded authorities. Operationally, this is measurable: (1) agent-hours/day executed within approved trust scopes, (2) exception rate (percentage of actions requiring human escalation), (3) context freshness SLA under contested conditions, and (4) control-plane mean time to recover (MTTR) during deception and jamming. In contested environments, autonomy will not be optional; it will be required to operate inside human relevance windows, especially across cyber, electronic warfare, and battle management workflows. The practical implication is that the battlespace becomes a compute-and-agency competition: who can sense faster, interpret more reliably, and execute within policy constraints at machine speed.
 
 \begin{calloutquote}
-``You can't recruit your way out of a compute deficit.''
+You can't recruit your way out of a compute deficit.
 \end{calloutquote}
 
 \section{Human Relevance Windows}\label{human-relevance-windows}
@@ -306,7 +306,7 @@ Force creation does not eliminate human error; it moves it upstream into specifi
 A mature autonomy program must measure these failure modes explicitly and treat them as correctable operational risks.
 
 \begin{calloutquote}
-``Humans govern the loop; machines execute it.''
+Humans govern the loop; machines execute it.
 \end{calloutquote}
 
 \section{Agent-on-Agent Conflict}\label{agent-on-agent-conflict}
@@ -336,7 +336,7 @@ Scenario (contested comms, high tempo): Under intermittent connectivity, a battl
 This shift is structurally driven by operational tempo, contestation, and scale asymmetry.
 
 \begin{calloutquote}
-``If humans must approve every action, you have already lost the tempo advantage.''
+If humans must approve every action, you have already lost the tempo advantage.
 \end{calloutquote}
 
 \section{Current Developments and Case Studies: Evidence of the Gap in DoW Adoption}\label{current-developments-and-case-studies-evidence-of-the-gap-in-dod-adoption}

--- a/tex/paper_preamble.tex
+++ b/tex/paper_preamble.tex
@@ -64,8 +64,8 @@
   borderline west={2.2pt}{0pt}{BrandAccent}
 }
 \newenvironment{calloutquote}
-  {\begin{calloutquotebox}\centering\bfseries\large\itshape}
-  {\par\smallskip\hfill{\normalfont\small\textcolor{BrandGray}{--- \AuthorName}}\end{calloutquotebox}}
+  {\begin{calloutquotebox}\centering\bfseries\large}
+  {\end{calloutquotebox}}
 
 % Readable monospaced code block (pdfTeX-compatible)
 \newtcblisting{yamlblock}{


### PR DESCRIPTION
Closes #72.

- Updates `calloutquote` rendering to remove author attribution.
- Removes TeX quotation wrappers from calloutquote contents so they read as plain impactful statements.