### PR TITLE
Add TOC + YAML caption + no-indent paragraphs (closes #74 #75 #76)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -31,6 +31,9 @@
 \noindent\textcolor{BrandGray}{\small\textbf{Distribution:} Public.\quad\textbf{Disclaimer:} Views are the author's and do not represent official policy.}
 \newpage
 
+\tableofcontents
+\newpage
+
 \begin{execsummary}
 % autopilot: pull-quotes insertion requested in PR
 \textbf{The shift:} The DoW is adopting AI as a \emph{force multiplier} (assistants) while the strategic inflection is \emph{force creation}: autonomous, intent-driven agents operate with delegated authority, scaling through compute rather than human labor.
@@ -116,6 +119,8 @@ Trust scope decomposes into four explicit parameters. Each parameter is measurab
 \end{itemize}
 
 A required Trust Scope Manifest per agent family (e.g., enterprise, intel, cyber, battle management) includes approval gates and escalation triggers. Below is a drop-in YAML structure, expanded with DoW-specific examples for clarity:
+
+\noindent\textcolor{BrandGray}{\small\textbf{Trust Scope Manifest (YAML)}}
 
 \begin{yamlblock}
 trust_scope_manifest:

--- a/tex/paper_preamble.tex
+++ b/tex/paper_preamble.tex
@@ -12,6 +12,11 @@
 \usepackage[letterpaper,margin=1in]{geometry}
 \usepackage{microtype}
 \usepackage{setspace}
+% Paragraph formatting
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{0.35em}
+% Table of contents depth
+\setcounter{tocdepth}{2}
 \setstretch{1.12}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}


### PR DESCRIPTION
Closes #74.
Closes #75.
Closes #76.

- Adds a table of contents after the title page.
- Adds a small caption label above the Trust Scope Manifest YAML block.
- Sets global paragraph indentation to 0 and adds light paragraph spacing.