### PR TITLE
Tighten TOC spacing + keep it one page (closes #78)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -31,7 +31,7 @@
 \noindent\textcolor{BrandGray}{\small\textbf{Distribution:} Public.\quad\textbf{Disclaimer:} Views are the author's and do not represent official policy.}
 \newpage
 
-\tableofcontents
+{\small\renewcommand{\baselinestretch}{0.92}\selectfont\tableofcontents}
 \newpage
 
 \begin{execsummary}

--- a/tex/paper_preamble.tex
+++ b/tex/paper_preamble.tex
@@ -51,6 +51,10 @@
 \usepackage{listings}
 \usepackage{tabularx}
 \usepackage{enumitem}
+\usepackage{tocloft}
+% Tighten ToC spacing (keep it one page)
+\setlength{\cftbeforesecskip}{0pt}
+\setlength{\cftbeforesubsecskip}{0pt}
 \tcbuselibrary{listingsutf8,breakable}
 
 % Pandoc compatibility (some markdown->latex conversions emit this)


### PR DESCRIPTION
Closes #78.

- Adds `tocloft` and tightens TOC vertical spacing.
- Renders the TOC in a smaller font with slightly reduced line spacing to keep it on one page.