### PR TITLE
Walk back TOC tightness + force TOC black (closes #80)

### DIFF
--- a/papers/agentic-force-creation/tex/paper.tex
+++ b/papers/agentic-force-creation/tex/paper.tex
@@ -31,7 +31,7 @@
 \noindent\textcolor{BrandGray}{\small\textbf{Distribution:} Public.\quad\textbf{Disclaimer:} Views are the author's and do not represent official policy.}
 \newpage
 
-{\small\renewcommand{\baselinestretch}{0.92}\selectfont\tableofcontents}
+{\small\renewcommand{\baselinestretch}{0.96}\selectfont\tableofcontents}
 \newpage
 
 \begin{execsummary}

--- a/tex/paper_preamble.tex
+++ b/tex/paper_preamble.tex
@@ -52,9 +52,14 @@
 \usepackage{tabularx}
 \usepackage{enumitem}
 \usepackage{tocloft}
-% Tighten ToC spacing (keep it one page)
-\setlength{\cftbeforesecskip}{0pt}
-\setlength{\cftbeforesubsecskip}{0pt}
+% Tighten ToC spacing (keep it one page, but not overly cramped)
+\setlength{\cftbeforesecskip}{1.5pt}
+\setlength{\cftbeforesubsecskip}{1pt}
+% Keep ToC text black (override any inherited color)
+\renewcommand{\cftsecfont}{\color{black}}
+\renewcommand{\cftsecpagefont}{\color{black}}
+\renewcommand{\cftsubsecfont}{\color{black}}
+\renewcommand{\cftsubsecpagefont}{\color{black}}
 \tcbuselibrary{listingsutf8,breakable}
 
 % Pandoc compatibility (some markdown->latex conversions emit this)


### PR DESCRIPTION
Closes #80.

- Slightly loosens TOC spacing (less cramped) while keeping it one page.
- Forces TOC entry text and page numbers to black via `tocloft` font hooks.